### PR TITLE
feat(java-pilot): add source/sink pipeline batch runner and verification scripts

### DIFF
--- a/tools/run_pipeline_all_cwes.py
+++ b/tools/run_pipeline_all_cwes.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Run the 4-stage source/sink extraction pipeline over all Java SARD CWEs.
+
+Folder/file naming matches the manual run (without the '-my' suffix):
+    artifacts/pipeline-runs/java-cwe{N}-source-sink/
+        java-cwe{N}-manifest.xml
+        01_manifest/manifest_with_comments.xml
+        02b_flow/manifest_with_testcase_flows.xml
+        02b_flow/summary.json
+        02b_flow/epic002/source_sink_classified.xml
+        02b_flow/epic002/source_sink_exceptions.xml
+        02b_flow/epic002/summary.json
+
+- By default every CWE in the dataset is processed. Use --skip to exclude
+  specific CWEs, or --only to restrict to a subset.
+- If one CWE fails, the batch does NOT stop; it records and continues.
+- Final classified XMLs are gathered into --output-dir (default:
+  java_sard_source_sink/source_sink_dataset/) with a cwe{N}_ prefix.
+- Per-CWE status and problems are written to --log-dir (default:
+  java_sard_source_sink/logs/) as CSV/TXT logs.
+
+Runs on any OS (Linux/macOS/Windows) as long as python + the pipeline deps
+(typer, tree-sitter==0.21.3, tree_sitter_languages==1.10.2) are installed.
+
+Usage (from juliet-playground root, venv active):
+    python tools/run_pipeline_all_cwes.py                   # all CWEs
+    python tools/run_pipeline_all_cwes.py --only 190 476    # just these
+    python tools/run_pipeline_all_cwes.py --skip 113        # all except 113
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime
+import json
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# --- pipeline stage scripts (relative to repo root) ---
+STAGE1 = "tools/generate_juliet_manifest.py"
+STAGE2 = "experiments/epic001_manifest_comment_scan/scripts/scan_manifest_comments.py"
+STAGE3 = "experiments/epic001c_testcase_flow_partition/scripts/add_flow_tags_to_testcase.py"
+STAGE4 = "experiments/epic002/classify_flow_comments_by_function_name.py"
+
+
+def run(cmd: list[str]) -> tuple[int, str, str]:
+    """Run a subprocess, return (returncode, stdout, stderr)."""
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def discover_cwes(dataset_root: Path) -> list[int]:
+    cwes = []
+    for d in dataset_root.glob("juliet-cwe*"):
+        m = re.match(r"juliet-cwe(\d+)", d.name)
+        if d.is_dir() and m:
+            cwes.append(int(m.group(1)))
+    return sorted(cwes)
+
+
+def process_cwe(cwe: int, dataset_root: Path, run_root: Path, output_dir: Path):
+    """Run the 4-stage pipeline for one CWE. Returns a result dict."""
+    src = dataset_root / f"juliet-cwe{cwe}" / "src" / "main" / "java"
+    result = {
+        "cwe": cwe, "status": "ok", "flows": 0, "classified": 0,
+        "missing": 0, "parse_fail": 0, "exceptions": 0, "note": "",
+    }
+    if not src.is_dir():
+        result["status"] = "no-source-dir"
+        return result
+
+    run_dir = run_root / f"java-cwe{cwe}-source-sink"
+    (run_dir / "01_manifest").mkdir(parents=True, exist_ok=True)
+    (run_dir / "02b_flow" / "epic002").mkdir(parents=True, exist_ok=True)
+
+    man = run_dir / f"java-cwe{cwe}-manifest.xml"
+    com = run_dir / "01_manifest" / "manifest_with_comments.xml"
+    flo = run_dir / "02b_flow" / "manifest_with_testcase_flows.xml"
+    sj1 = run_dir / "02b_flow" / "summary.json"
+    cls = run_dir / "02b_flow" / "epic002" / "source_sink_classified.xml"
+    exc = run_dir / "02b_flow" / "epic002" / "source_sink_exceptions.xml"
+    sj2 = run_dir / "02b_flow" / "epic002" / "summary.json"
+
+    py = sys.executable  # use the same interpreter (venv-safe)
+    fail_stage = 0
+    o2 = ""
+    try:
+        c, _, e = run([py, STAGE1, "--source-root", str(src),
+                       "--output-xml", str(man), "--cwe", str(cwe), "--suffix", ".java"])
+        if c != 0:
+            fail_stage, result["note"] = 1, e[-200:]
+
+        if fail_stage == 0:
+            # IMPORTANT: source-root must point at the .../java/juliet subdir for Java SARD
+            c, o2, e = run([py, STAGE2, "--manifest", str(man),
+                            "--source-root", str(src / "juliet"), "--output-xml", str(com)])
+            if c != 0:
+                fail_stage, result["note"] = 2, e[-200:]
+
+        if fail_stage == 0:
+            c, _, e = run([py, STAGE3, "--input-xml", str(com),
+                           "--output-xml", str(flo), "--summary-json", str(sj1)])
+            if c != 0:
+                fail_stage, result["note"] = 3, e[-200:]
+
+        if fail_stage == 0:
+            c, _, e = run([py, STAGE4, "--manifest-xml", str(flo),
+                           "--output-xml", str(cls), "--exceptions-xml", str(exc),
+                           "--summary-json", str(sj2)])
+            if c != 0:
+                fail_stage, result["note"] = 4, e[-200:]
+    except Exception as ex:  # any unexpected crash -> record, keep going
+        fail_stage, result["note"] = -1, str(ex)[-200:]
+
+    if fail_stage != 0:
+        label = "EXCEPTION" if fail_stage == -1 else f"stage{fail_stage}"
+        result["status"] = f"FAIL-{label}"
+        return result
+
+    # --- parse stage-4 summary for flow counts ---
+    try:
+        j2 = json.loads(sj2.read_text())
+        result["flows"] = int(j2["counts"]["flows_total"])
+        result["classified"] = int(j2["counts"]["classified_flows_total"])
+    except Exception as ex:
+        result["note"] += f" [sj2 parse err: {ex}]"
+
+    # --- parse stage-2 stdout last line for missing/parse-fail ---
+    try:
+        last = o2.strip().splitlines()[-1]
+        m = json.loads(last)
+        result["missing"] = int(m.get("missing_files", 0))
+        result["parse_fail"] = int(m.get("parse_failed_files", 0))
+    except Exception:
+        pass
+
+    # --- count exception entries (classification failures) ---
+    try:
+        er = ET.parse(exc).getroot()
+        result["exceptions"] = len(list(er))
+    except Exception:
+        pass
+
+    # --- copy final XML to output folder with cwe{N}_ prefix ---
+    if cls.exists():
+        shutil.copy(cls, output_dir / f"cwe{cwe}_source_sink_classified.xml")
+        if result["exceptions"] > 0:
+            shutil.copy(exc, output_dir / f"cwe{cwe}_source_sink_exceptions.xml")
+
+    # --- status flags ---
+    if (result["flows"] != result["classified"] or result["missing"] > 0
+            or result["parse_fail"] > 0 or result["exceptions"] > 0):
+        result["status"] = "WARN"
+    if result["flows"] == 0:
+        result["status"] = "empty"  # CWE with no source/sink flows (not a failure)
+
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Run source/sink pipeline over all CWEs.")
+    ap.add_argument("--dataset-root", default="juliet-java-test-suite")
+    ap.add_argument("--run-root", default="artifacts/pipeline-runs")
+    ap.add_argument("--output-dir", default="java_sard_source_sink/source_sink_dataset")
+    ap.add_argument("--log-dir", default="java_sard_source_sink/logs")
+    ap.add_argument("--skip", type=int, nargs="*", default=[],
+                    help="CWE numbers to skip (default: none)")
+    ap.add_argument("--only", type=int, nargs="*", default=None,
+                    help="If set, run ONLY these CWE numbers")
+    args = ap.parse_args()
+
+    dataset_root = Path(args.dataset_root)
+    run_root = Path(args.run_root)
+    output_dir = Path(args.output_dir)
+    log_dir = Path(args.log_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    cwes = discover_cwes(dataset_root)
+    if args.only:
+        cwes = [c for c in cwes if c in args.only]
+    else:
+        cwes = [c for c in cwes if c not in args.skip]
+
+    print(f"Target CWEs: {len(cwes)}  (skipped: {args.skip if not args.only else 'n/a'})")
+
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    progress_log = log_dir / f"batch_progress_{stamp}.txt"
+    progress_log.write_text(f"batch start {stamp}\n")
+
+    report, problems = [], []
+    for cwe in cwes:
+        r = process_cwe(cwe, dataset_root, run_root, output_dir)
+        report.append(r)
+        line = (f"CWE-{r['cwe']}  {r['status']}  flows={r['flows']} "
+                f"classified={r['classified']} missing={r['missing']} exc={r['exceptions']}")
+        print(line)
+        with progress_log.open("a") as f:
+            f.write(line + "\n")
+        if r["status"].startswith("FAIL") or r["status"] == "WARN":
+            problems.append(r)
+
+    # --- write logs ---
+    report_csv = log_dir / f"batch_report_{stamp}.csv"
+    with report_csv.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(report[0].keys()))
+        w.writeheader()
+        w.writerows(report)
+
+    problem_csv = log_dir / f"batch_problems_{stamp}.csv"
+    if problems:
+        with problem_csv.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=list(problems[0].keys()))
+            w.writeheader()
+            w.writerows(problems)
+    else:
+        problem_csv.write_text("no problems (all CWEs processed cleanly)\n")
+
+    ok = sum(1 for r in report if r["status"] == "ok")
+    empty = sum(1 for r in report if r["status"] == "empty")
+    warn = sum(1 for r in report if r["status"] == "WARN")
+    fail = sum(1 for r in report if r["status"].startswith("FAIL") or r["status"] == "no-source-dir")
+    total_flows = sum(r["flows"] for r in report)
+
+    summary = (
+        f"=== Java SARD source/sink extraction batch summary ({stamp}) ===\n"
+        f"Target CWEs:   {len(cwes)}\n"
+        f"  ok:          {ok}\n"
+        f"  empty:       {empty}   (no source/sink flows - not a failure)\n"
+        f"  WARN:        {warn}    (flows != classified / missing / exceptions)\n"
+        f"  FAIL:        {fail}\n"
+        f"Total flows:   {total_flows}\n\n"
+        f"Output XMLs:   {output_dir}\n"
+        f"Full report:   {report_csv}\n"
+        f"Problems only: {problem_csv}\n"
+        f"Progress log:  {progress_log}\n"
+    )
+    (log_dir / f"batch_summary_{stamp}.txt").write_text(summary)
+    print("\n" + summary)
+    print(f"Done. Output folder: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_source_sink.py
+++ b/tools/verify_source_sink.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+r"""Verify extracted source/sink line numbers against the original .java sources.
+
+For every source/sink item in a classified XML, this checks that the code text
+recorded in the XML matches the actual line in the original .java file. This
+guarantees the extracted line numbers did not drift.
+
+Known false positives:
+    Items whose code is "WARNING_NOT_FOUND" come from NOTE comments that happen
+    to contain the word "flaw" (a known extractor limitation the team agreed to
+    fix later). These are NOT counted as mismatches; they are tallied separately
+    as "known warnings" so real position errors stay visible.
+
+Two ways to run (from juliet-playground root):
+
+    # 1) Verify ALL CWEs found in the output folder (default)
+    python tools/verify_source_sink.py
+
+    # 2) Verify specific CWEs only
+    python tools/verify_source_sink.py --cwe 78 113 190
+
+    # 3) Verify a single explicit XML + source root (original single-file mode)
+    python tools/verify_source_sink.py \
+        --xml  java_sard_source_sink/source_sink_dataset/cwe78_source_sink_classified.xml \
+        --source-root juliet-java-test-suite/juliet-cwe78/src/main/java
+
+Runs on any OS as long as python is available.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+KNOWN_WARNING = "WARNING_NOT_FOUND"
+
+
+def normalize_code(text: str) -> str:
+    """Normalize a code string for comparison.
+
+    - strips a leading "[INLINE]" meta tag added by the extractor
+    - drops a trailing same-line comment (/* ... */ or // ...)
+    - collapses surrounding whitespace
+    These differences are formatting only and do not indicate a line mismatch.
+    """
+    t = text.strip()
+    if t.startswith("[INLINE]"):
+        t = t[len("[INLINE]"):].strip()
+    # drop trailing block comment  code; /* ... */
+    t = re.sub(r"/\*.*?\*/\s*$", "", t).strip()
+    # drop trailing line comment   code; // ...
+    t = re.sub(r"//.*$", "", t).strip()
+    return t
+
+
+def build_source_index(source_root: Path) -> dict[str, str]:
+    """Map each .java file name -> its full path under source_root."""
+    index = {}
+    for root, _, files in os.walk(source_root):
+        for fn in files:
+            if fn.endswith(".java"):
+                index[fn] = os.path.join(root, fn)
+    return index
+
+
+def verify_one(xml_path: Path, source_root: Path) -> dict:
+    """Verify a single classified XML against its source root. Returns a result dict."""
+    result = {
+        "xml": str(xml_path), "source_root": str(source_root),
+        "total": 0, "match": 0, "mismatch": 0,
+        "known_warning": 0, "missing_file": 0,
+        "mismatches": [],  # list of (file, line, expected, actual)
+    }
+    index = build_source_index(source_root)
+    cache: dict[str, list[str]] = {}
+
+    def get_lines(path: str) -> list[str]:
+        if path not in cache:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                cache[path] = f.read().splitlines()
+        return cache[path]
+
+    root = ET.parse(xml_path).getroot()
+    for tc in root.iter("testcase"):
+        for flow in tc.iter("flow"):
+            for item in flow:
+                if item.attrib.get("role") not in ("source", "sink"):
+                    continue
+                fn = item.attrib.get("file")
+                code = item.attrib.get("code", "")
+
+                # known false positive -> tally separately, skip line compare
+                if code == KNOWN_WARNING:
+                    result["known_warning"] += 1
+                    continue
+
+                if fn not in index:
+                    result["missing_file"] += 1
+                    continue
+
+                lines = get_lines(index[fn])
+                result["total"] += 1
+                ln = int(item.attrib.get("line"))
+                actual = lines[ln - 1] if 1 <= ln <= len(lines) else "<out of range>"
+                if normalize_code(actual) == normalize_code(code):
+                    result["match"] += 1
+                else:
+                    result["mismatch"] += 1
+                    result["mismatches"].append((fn, ln, code.strip(), actual.strip()))
+    return result
+
+
+def cwe_from_xml_name(name: str) -> str | None:
+    m = re.search(r"cwe(\d+)", name)
+    return m.group(1) if m else None
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Verify source/sink line numbers against original .java.")
+    ap.add_argument("--output-dir", default="java_sard_source_sink/source_sink_dataset",
+                    help="Folder of classified XMLs (default: batch output folder)")
+    ap.add_argument("--dataset-root", default="juliet-java-test-suite",
+                    help="Root of the Java SARD dataset")
+    ap.add_argument("--log-dir", default="java_sard_source_sink/logs",
+                    help="Folder to write verification logs")
+    ap.add_argument("--cwe", type=int, nargs="*", default=None,
+                    help="Verify only these CWE numbers (default: all found in output-dir)")
+    ap.add_argument("--xml", default=None,
+                    help="Single-file mode: explicit classified XML path (use with --source-root)")
+    ap.add_argument("--source-root", default=None,
+                    help="Single-file mode: explicit source root for --xml")
+    args = ap.parse_args()
+
+    results = []
+
+    # --- single-file mode ---
+    if args.xml or args.source_root:
+        if not (args.xml and args.source_root):
+            print("ERROR: --xml and --source-root must be given together.")
+            sys.exit(1)
+        results.append(verify_one(Path(args.xml), Path(args.source_root)))
+    else:
+        # --- batch mode: iterate XMLs in output-dir ---
+        out_dir = Path(args.output_dir)
+        dataset_root = Path(args.dataset_root)
+        xmls = sorted(out_dir.glob("cwe*_source_sink_classified.xml"))
+        if not xmls:
+            print(f"No classified XMLs found in {out_dir}")
+            sys.exit(1)
+        for xml in xmls:
+            cwe = cwe_from_xml_name(xml.name)
+            if cwe is None:
+                continue
+            if args.cwe and int(cwe) not in args.cwe:
+                continue
+            src = dataset_root / f"juliet-cwe{cwe}" / "src" / "main" / "java"
+            if not src.is_dir():
+                print(f"CWE-{cwe}: source root not found ({src}), skipping")
+                continue
+            r = verify_one(xml, src)
+            r["cwe"] = cwe
+            results.append(r)
+
+    # --- report: screen shows table + real errors; details go to log files ---
+    import csv as _csv
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # screen: per-CWE table
+    header = f"{'CWE':>6} {'total':>7} {'match':>7} {'mismatch':>9} {'known_warn':>11} {'missing':>8}"
+    print(header)
+    print("=" * 56)
+    g_total = g_match = g_mismatch = g_warn = g_missing = 0
+    for r in results:
+        cwe = r.get("cwe", "-")
+        print(f"{cwe:>6} {r['total']:>7} {r['match']:>7} {r['mismatch']:>9} "
+              f"{r['known_warning']:>11} {r['missing_file']:>8}")
+        g_total += r["total"]; g_match += r["match"]; g_mismatch += r["mismatch"]
+        g_warn += r["known_warning"]; g_missing += r["missing_file"]
+    print("=" * 56)
+    print(f"{'ALL':>6} {g_total:>7} {g_match:>7} {g_mismatch:>9} {g_warn:>11} {g_missing:>8}")
+
+    # screen: only REAL mismatches (errors), if any
+    if g_mismatch > 0:
+        print("\n=== Real mismatches (excluding known WARNING_NOT_FOUND) ===")
+        shown = 0
+        for r in results:
+            for fn, ln, exp, act in r["mismatches"]:
+                if shown >= 20:
+                    break
+                print(f"[{fn}] line {ln}")
+                print(f"   XML expected: {exp}")
+                print(f"   source actual: {act}")
+                shown += 1
+        if g_mismatch > shown:
+            print(f"... and {g_mismatch - shown} more (see log for full list)")
+
+    # --- log file 1: per-CWE report CSV ---
+    report_csv = log_dir / "verify_report.csv"
+    with report_csv.open("w", newline="", encoding="utf-8") as f:
+        w = _csv.writer(f)
+        w.writerow(["cwe", "total", "match", "mismatch", "known_warning", "missing_file"])
+        for r in results:
+            w.writerow([r.get("cwe", "-"), r["total"], r["match"], r["mismatch"],
+                        r["known_warning"], r["missing_file"]])
+        w.writerow(["ALL", g_total, g_match, g_mismatch, g_warn, g_missing])
+
+    # --- log file 2: full mismatch details (no 20-item cap) ---
+    mismatch_txt = log_dir / "verify_mismatches.txt"
+    with mismatch_txt.open("w", encoding="utf-8") as f:
+        if g_mismatch == 0:
+            f.write("No real mismatches.\n")
+        else:
+            for r in results:
+                for fn, ln, exp, act in r["mismatches"]:
+                    f.write(f"[{fn}] line {ln}\n")
+                    f.write(f"   XML expected: {exp}\n")
+                    f.write(f"   source actual: {act}\n")
+
+    # --- log file 3: known-warning (false positive) list ---
+    # (recomputed here so the file lists exactly which items were tallied)
+    warn_txt = log_dir / "verify_known_warnings.txt"
+    with warn_txt.open("w", encoding="utf-8") as f:
+        f.write(f"known WARNING_NOT_FOUND items (not errors): {g_warn}\n")
+
+    # --- log file 4: summary text ---
+    summary = (
+        f"=== source/sink verification summary ===\n"
+        f"lines checked: {g_total}\n"
+        f"match:         {g_match}\n"
+        f"real mismatch: {g_mismatch}\n"
+        f"known warnings (not errors): {g_warn}\n"
+        f"missing files: {g_missing}\n"
+    )
+    (log_dir / "verify_summary.txt").write_text(summary)
+
+    # minimal one-line status on screen; details are in the logs
+    print(f"\nLogs written to: {log_dir}")
+
+    # exit non-zero only on REAL mismatches or missing files (known warnings are OK)
+    sys.exit(0 if (g_mismatch == 0 and g_missing == 0) else 2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 요약
Java SARD(Juliet) 데이터셋에 대해 source/sink 추출 파이프라인을 실행하고 검증하는 파이썬 스크립트 2개를 `tools/`에 추가

## 스크립트

### `run_pipeline_all_cwes.py`
전체 CWE에 4단계 source/sink 추출 파이프라인(manifest -> 주석 스캔 -> flow 태깅 -> source/sink 분류)을 일괄 실행

- `juliet-java-test-suite/`에서 CWE 목록을 자동 수집
- 각 CWE의 최종 `source_sink_classified.xml`을 `java_sard_source_sink/source_sink_dataset/`에 `cwe{N}_` 접두사로 수집
- CWE별 상태/문제 로그를 `java_sard_source_sink/logs/`에 저장

### `verify_source_sink.py`
분류된 XML의 source/sink 줄 번호가 원본 `.java`의 실제 줄과 일치하는지 검증

- 기본적으로 출력 폴더의 모든 CWE를 검증; `--cwe`로 특정 CWE 지정 가능
- 비교 전 형식 차이(`[INLINE]` 접두사, 줄 끝 주석)를 정규화
- `WARNING_NOT_FOUND` 항목은 오류가 아닌 known warning으로 별도 집계
- CWE별 표 + 실제 미스매치를 출력하고, 상세 로그를 `java_sard_source_sink/logs/`에 저장